### PR TITLE
Fix jar name in backend build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:11
 ARG JAR_FILE=build/libs/*.jar
-COPY ${JAR_FILE} fasescape.jar
-ENTRYPOINT ["java", "-jar", "fasescape.jar"]
+COPY ${JAR_FILE} facescape.jar
+ENTRYPOINT ["java", "-jar", "facescape.jar"]

--- a/cicd/ReadMe.md
+++ b/cicd/ReadMe.md
@@ -34,7 +34,8 @@ CI / CD를 위한 서버는 gitlab의 webhook을 감지, 결과물을 빌드 하
 1-2) Frontend에서 게임 화면의 경우 용량이 너무 크고, 런타임에 예상하지 못한 버그들이 많이 발생하였습니다. 따라서 해당 부분은 실제로 사람이 테스트를 하고 빌드하는 것이 낫다고 판단하여 CI/CD 과정에서 제거하고 SCP로 수동으로 배포하였습니다. 
 
 
-## Backend Pipe Line 
+## Backend Pipe Line
+Dockerfile에서 빌드된 JAR(`build/libs/*.jar`) 파일을 `facescape.jar`로 복사하여 실행합니다.
 ```
 pipeline {
     

--- a/exec/readme.md
+++ b/exec/readme.md
@@ -11,7 +11,8 @@ DB: Maria DB
 1) Spring
 ```
 ./gradlew build
-docker build -t . 이미지명  
+# Dockerfile에서는 생성된 JAR을 `facescape.jar`로 복사합니다
+docker build -t . 이미지명
 docker run -itd --name $container_name --network host $repository
 ```
 


### PR DESCRIPTION
## Summary
- fix Dockerfile jar naming
- clarify pipeline docs
- document jar name in setup instructions

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*
- `npm test --silent` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687758a3e4c883319ec4d02caf7c0ff1